### PR TITLE
fix ssh_authorized_keys typo

### DIFF
--- a/rwlaunchpad/plugins/rwvnfm/rift/tasklets/rwvnfmtasklet/rwvnfmtasklet.py
+++ b/rwlaunchpad/plugins/rwvnfm/rift/tasklets/rwvnfmtasklet/rwvnfmtasklet.py
@@ -509,7 +509,7 @@ class VirtualDeploymentUnitRecord(object):
         self._log.debug("Current cloud init dict is {}".format(cloud_init_dict))
 
         for key_pair in self._vnfr._vnfr_msg.cloud_config.key_pair:
-            if "ssh_authorized_key" not in cloud_init_dict:
+            if "ssh_authorized_keys" not in cloud_init_dict:
                 cloud_init_dict["ssh_authorized_keys"] = list()
             cloud_init_dict["ssh_authorized_keys"].append(key_pair.key)
 


### PR DESCRIPTION
When > 1 ssh key is applied, only last ssh key is utilized due to bug.